### PR TITLE
refactor: use `Predicate` replace `ArrowPredicate`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use thiserror::Error;
 
 pub mod ord;
 pub mod reader;
+pub use reader::*;
 
 #[derive(Debug, Error)]
 pub enum Error {

--- a/src/ord/mod.rs
+++ b/src/ord/mod.rs
@@ -1,42 +1,35 @@
-use arrow::{array::Datum, compute::kernels::cmp};
+use arrow::{
+    array::{BooleanArray, Datum},
+    buffer::BooleanBuffer,
+    compute::kernels::cmp,
+};
 use arrow_schema::ArrowError;
 
 use crate::reader::filter::Filter;
 
+/// Perform `left < right` operation on two [`Datum`].
 pub fn lt(lhs: &dyn Datum, rhs: &dyn Datum) -> Result<Filter, ArrowError> {
     Ok(Filter::new(cmp::lt(lhs, rhs)?))
 }
 
+/// Perform `left <= right` operation on two [`Datum`].
 pub fn lt_eq(lhs: &dyn Datum, rhs: &dyn Datum) -> Result<Filter, ArrowError> {
     Ok(Filter::new(cmp::lt_eq(lhs, rhs)?))
 }
 
+/// Perform `left > right` operation on two [`Datum`].
 pub fn gt(lhs: &dyn Datum, rhs: &dyn Datum) -> Result<Filter, ArrowError> {
     Ok(Filter::new(cmp::gt(lhs, rhs)?))
 }
 
+/// Perform `left >= right` operation on two [`Datum`].
 pub fn gt_eq(lhs: &dyn Datum, rhs: &dyn Datum) -> Result<Filter, ArrowError> {
     Ok(Filter::new(cmp::gt_eq(lhs, rhs)?))
 }
 
-// pub fn eq(lhs: &dyn Datum, rhs: &dyn Datum) -> Result<BooleanArray, ArrowError> {
-//     let ge = cmp::gt_eq(lhs, rhs)?;
-//     let le = cmp::lt_eq(lhs, rhs)?;
-//     let res = arrow::array::BooleanArray::from_iter(ge.iter().zip(le.iter()).map(|b| match b {
-//         (None, _) => None,
-//         (_, None) => None,
-//         (Some(a), Some(b)) => Some(a & b),
-//     }));
-//     Ok(BooleanArray::new(res))
-// }
-
-pub fn neq(lhs: &dyn Datum, rhs: &dyn Datum) -> Result<Filter, ArrowError> {
-    let ge = cmp::gt(lhs, rhs)?;
-    let le = cmp::lt(lhs, rhs)?;
-    let res = arrow::array::BooleanArray::from_iter(ge.iter().zip(le.iter()).map(|b| match b {
-        (None, _) => Some(true),
-        (_, None) => Some(true),
-        (Some(a), Some(b)) => Some(a || b),
-    }));
-    Ok(Filter::new(res))
+pub fn inf(datum: &dyn Datum) -> Result<Filter, ArrowError> {
+    let len = datum.get().0.len();
+    Ok(Filter {
+        array: BooleanArray::new(BooleanBuffer::collect_bool(len, |_| true), None),
+    })
 }

--- a/src/reader/filter.rs
+++ b/src/reader/filter.rs
@@ -1,9 +1,6 @@
 use std::sync::Arc;
 
-use arrow::{
-    array::{BooleanArray, RecordBatch},
-    buffer::BooleanBuffer,
-};
+use arrow::array::{BooleanArray, RecordBatch};
 use arrow_schema::{Field, Schema};
 use parquet::{
     arrow::arrow_reader::{
@@ -45,12 +42,6 @@ pub struct Filter {
 impl Filter {
     pub(crate) fn new(array: BooleanArray) -> Self {
         Self { array }
-    }
-
-    pub fn fill(len: usize, value: bool) -> Self {
-        Self {
-            array: BooleanArray::new(BooleanBuffer::collect_bool(len, |_| value), None),
-        }
     }
 
     pub(crate) fn boolean_array(&self) -> &BooleanArray {


### PR DESCRIPTION
- add `ArrowPredicate` trait to prevent user from accidentally using `AislePredicate`s like `AislePredicateFn` and get confusing results
- fix range bugs in cross page test and add multiple ranges test