### PR TITLE
add benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,11 @@ harness = false
 name = "reader"
 required-features = ["tokio"]
 
+[[bench]]
+harness = false
+name = "read_bench"
+required-features = ["tokio"]
+
 [dependencies]
 arrow = { version = "55.1.0", default-features = false }
 arrow-schema = { version = "55.1.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,19 @@ edition = "2024"
 description = "An efficient Parquet file reader."
 license = "Apache-2.0"
 
+[features]
+default = []
+tokio = ["dep:tokio"]
+
+[[example]]
+name = "reader"
+required-features = ["tokio"]
+
+[[bench]]
+harness = false
+name = "reader"
+required-features = ["tokio"]
+
 [dependencies]
 arrow = { version = "55.1.0", default-features = false }
 arrow-schema = { version = "55.1.0", default-features = false }
@@ -13,6 +26,7 @@ parquet = { version = "55.1.0", default-features = false, features = [
     "arrow",
     "async",
 ] }
+tokio = { version = "1.44.2", optional = true, features = ["full"] }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async_tokio"] }

--- a/benches/read_bench.rs
+++ b/benches/read_bench.rs
@@ -1,0 +1,325 @@
+use std::sync::Arc;
+
+use aisle::{
+    predicate::AislePredicate,
+    reader::{predicate::AislePredicateFn, ParquetRecordBatchStreamBuilder},
+    ProjectionMask,
+};
+use arrow::{
+    array::{ArrayRef, Datum, RecordBatch, StringArray, UInt64Array, UInt8Array},
+    datatypes::{DataType, Field, Schema},
+};
+use fusio::{disk::TokioFs, fs::OpenOptions, path::Path, DynFs};
+use fusio_parquet::{reader::AsyncReader, writer::AsyncWriter};
+use futures_util::StreamExt;
+use parquet::{
+    arrow::{
+        arrow_reader::{ArrowPredicate, ArrowPredicateFn, ArrowReaderOptions},
+        AsyncArrowWriter,
+    },
+    basic::Compression,
+    file::properties::{EnabledStatistics, WriterProperties},
+    format::SortingColumn,
+    schema::types::ColumnPath,
+};
+use rand::{thread_rng, Rng};
+
+const QUERY_TIMES: usize = 100;
+
+fn get_ordered_record_batch(record_size: usize) -> RecordBatch {
+    let mut ids = vec![];
+    let mut ages = vec![];
+    let mut names = vec![];
+    for i in 0..record_size {
+        ids.push(i as u64);
+        ages.push((i % 256) as u8);
+        names.push(format!("{:08}", i));
+    }
+    RecordBatch::try_from_iter(vec![
+        ("id", Arc::new(UInt64Array::from(ids)) as ArrayRef),
+        ("name", Arc::new(StringArray::from(names)) as ArrayRef),
+        ("age", Arc::new(UInt8Array::from(ages)) as ArrayRef),
+    ])
+    .unwrap()
+}
+
+fn get_random_record_batch(record_size: usize) -> RecordBatch {
+    let mut ids = vec![];
+    let mut ages = vec![];
+    let mut names = vec![];
+    let mut rng = thread_rng();
+    for i in 0..record_size {
+        ids.push(rng.gen_range(0..record_size) as u64);
+        ages.push((rng.gen_range(0..record_size) % 256) as u8);
+        names.push(format!("{:08}", rng.gen_range(0..record_size * 10 + i)));
+    }
+    RecordBatch::try_from_iter(vec![
+        ("id", Arc::new(UInt64Array::from(ids)) as ArrayRef),
+        ("name", Arc::new(StringArray::from(names)) as ArrayRef),
+        ("age", Arc::new(UInt8Array::from(ages)) as ArrayRef),
+    ])
+    .unwrap()
+}
+
+async fn prepare_test_file(record_size: usize, sorted: bool) -> Path {
+    let dir = "./bench_data";
+    let filename = format!(
+        "bench_{}_{}M.parquet",
+        sorted.then_some("sorted").unwrap_or("random"),
+        record_size / 1048576
+    );
+
+    if !std::path::Path::new(dir).exists() {
+        std::fs::create_dir_all(dir).unwrap();
+    }
+
+    let path = Path::new(dir).unwrap().child(filename.as_str());
+
+    if !std::path::Path::new(&format!("{}/{}", dir, filename)).exists() {
+        let fs = Arc::new(TokioFs {}) as Arc<dyn DynFs>;
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::UInt64, false),
+            Field::new("name", DataType::Utf8, false),
+            Field::new("age", DataType::UInt8, false),
+        ]));
+
+        let mut properties_builder = WriterProperties::builder().set_compression(Compression::LZ4);
+        if sorted {
+            let column_paths = ColumnPath::new(vec!["id".into()]);
+            let sorting_columns = vec![SortingColumn::new(0, true, true)];
+            properties_builder = properties_builder
+                .set_column_bloom_filter_enabled(column_paths.clone(), true)
+                .set_column_statistics_enabled(column_paths, EnabledStatistics::Page)
+                .set_sorting_columns(Some(sorting_columns));
+        }
+        let mut writer = AsyncArrowWriter::try_new(
+            AsyncWriter::new(
+                fs.open_options(&path, OpenOptions::default().create(true).write(true))
+                    .await
+                    .unwrap(),
+            ),
+            schema,
+            Some(properties_builder.build()),
+        )
+        .unwrap();
+
+        let record_batch = if sorted {
+            get_ordered_record_batch(record_size)
+        } else {
+            get_random_record_batch(record_size)
+        };
+        writer.write(&record_batch).await.unwrap();
+        writer.close().await.unwrap();
+    }
+
+    path
+}
+
+async fn get_async_reader(path: &Path) -> AsyncReader {
+    let fs = Arc::new(TokioFs {});
+    let file = fs
+        .open_options(path, OpenOptions::default().read(true))
+        .await
+        .unwrap();
+    let size = file.size().await.unwrap();
+    AsyncReader::new(file, size).await.unwrap()
+}
+
+async fn bench_standard_reader(path: &Path, range: (u64, u64), options: ArrowReaderOptions) {
+    use arrow::compute::kernels::cmp::{gt, lt};
+    use parquet::arrow::arrow_reader::RowFilter;
+
+    let reader = get_async_reader(path).await;
+
+    let builder =
+        parquet::arrow::ParquetRecordBatchStreamBuilder::new_with_options(reader, options)
+            .await
+            .unwrap();
+    let parquet_schema = builder.parquet_schema();
+
+    let left_range_p = ArrowPredicateFn::new(
+        ProjectionMask::roots(parquet_schema, vec![0]),
+        move |batch| {
+            let datum = Arc::new(UInt64Array::new_scalar(range.0)) as Arc<dyn Datum>;
+            gt(batch.column(0), datum.as_ref())
+        },
+    );
+    let right_range_p = ArrowPredicateFn::new(
+        ProjectionMask::roots(parquet_schema, vec![0]),
+        move |batch| {
+            let datum = Arc::new(UInt64Array::new_scalar(range.1)) as Arc<dyn Datum>;
+            lt(batch.column(0), datum.as_ref())
+        },
+    );
+
+    let predicates: Vec<Box<dyn ArrowPredicate>> =
+        vec![Box::new(left_range_p), Box::new(right_range_p)];
+    let mut reader = builder
+        .with_row_filter(RowFilter::new(predicates).into())
+        .build()
+        .unwrap();
+
+    while let Some(_) = reader.next().await {}
+}
+
+async fn bench_pushdown_reader(path: &Path, range: (u64, u64), options: ArrowReaderOptions) {
+    use aisle::{
+        filter::RowFilter,
+        ord::{gt, lt},
+    };
+
+    let reader = get_async_reader(path).await;
+
+    let builder = ParquetRecordBatchStreamBuilder::new_with_options(reader, options)
+        .await
+        .unwrap();
+    let parquet_schema = builder.parquet_schema();
+
+    let left_range_p = AislePredicateFn::new(
+        ProjectionMask::roots(parquet_schema, vec![0]),
+        move |batch| {
+            let datum = Arc::new(UInt64Array::new_scalar(range.0)) as Arc<dyn Datum>;
+            gt(batch.column(0), datum.as_ref())
+        },
+    );
+    let right_range_p = AislePredicateFn::new(
+        ProjectionMask::roots(parquet_schema, vec![0]),
+        move |batch| {
+            let datum = Arc::new(UInt64Array::new_scalar(range.1)) as Arc<dyn Datum>;
+            lt(batch.column(0), datum.as_ref())
+        },
+    );
+
+    let predicates: Vec<Box<dyn AislePredicate>> =
+        vec![Box::new(left_range_p), Box::new(right_range_p)];
+    let mut reader = builder
+        .with_row_filter(RowFilter::new(predicates))
+        .build()
+        .unwrap();
+
+    while let Some(_) = reader.next().await {}
+}
+
+async fn bench_compare_readers(size: usize, ranges: Vec<(usize, usize)>, sorted: bool) -> Vec<f64> {
+    let path = prepare_test_file(size, sorted).await;
+    let mut times = vec![];
+    let start = std::time::Instant::now();
+    for (left, right) in ranges.iter() {
+        bench_standard_reader(
+            &path,
+            (*left as u64, *right as u64),
+            ArrowReaderOptions::new().with_page_index(false),
+        )
+        .await;
+    }
+    let time = start.elapsed().as_millis() as f64;
+    times.push(time / ranges.len() as f64);
+
+    let start = std::time::Instant::now();
+    for (left, right) in ranges.iter() {
+        bench_pushdown_reader(
+            &path,
+            (*left as u64, *right as u64),
+            ArrowReaderOptions::new().with_page_index(false),
+        )
+        .await;
+    }
+    let time = start.elapsed().as_millis() as f64;
+    times.push(time / ranges.len() as f64);
+
+    let start = std::time::Instant::now();
+    for (left, right) in ranges.iter() {
+        bench_standard_reader(
+            &path,
+            (*left as u64, *right as u64),
+            ArrowReaderOptions::new().with_page_index(true),
+        )
+        .await;
+    }
+    let time = start.elapsed().as_millis() as f64;
+    times.push(time / ranges.len() as f64);
+
+    let start = std::time::Instant::now();
+    for (left, right) in ranges.iter() {
+        bench_pushdown_reader(
+            &path,
+            (*left as u64, *right as u64),
+            ArrowReaderOptions::new().with_page_index(true),
+        )
+        .await;
+    }
+    let time = start.elapsed().as_millis() as f64;
+    times.push(time / ranges.len() as f64);
+
+    times
+}
+
+async fn compare_readers(sorted: bool, size: usize) -> Vec<f64> {
+    let mut rng = thread_rng();
+    let loop_num = rng.gen_range(QUERY_TIMES..QUERY_TIMES * 2);
+    let mut ranges = Vec::with_capacity(loop_num);
+    for _ in 0..loop_num {
+        let left = rng.gen_range(0..size);
+        let right = rng.gen_range(left..size);
+        ranges.push((left, right));
+    }
+    bench_compare_readers(size, ranges, sorted).await
+}
+
+#[tokio::main]
+async fn main() {
+    let mut ordered = vec![];
+    let mut unordered = vec![];
+    for size in [
+        1024 * 1024,
+        2 * 1024 * 1024,
+        4 * 1024 * 1024,
+        8 * 1024 * 1024,
+        16 * 1024 * 1024,
+        32 * 1024 * 1024,
+    ] {
+        ordered.push(compare_readers(true, size).await);
+        unordered.push(compare_readers(false, size).await);
+    }
+    println!("\t\tread ordered data (time in milliseconds)\t\t");
+    println!(
+        "+-----------------------------------------------------------------------------------------+"
+    );
+    println!(
+        "|num records|      Parquet      |    Aisle    |Parquet + Page index |  Aisle + Page index |"
+    );
+    for (i, times) in ordered.iter().enumerate() {
+        println!(
+            "|{:>6}M    |   {:>12.4}    |{:>12.4} |\t{:>12.4}\t    |\t{:>12.4}\t  |",
+            2_u32.pow(i as u32),
+            times[0],
+            times[1],
+            times[2],
+            times[3]
+        );
+    }
+    println!(
+        "+-----------------------------------------------------------------------------------------+"
+    );
+    println!();
+    println!("\t\tread totally random data (time in milliseconds)\t\t");
+    println!(
+        "+-----------------------------------------------------------------------------------------+"
+    );
+    println!(
+        "|num records|      Parquet      |    Aisle    |Parquet + Page index |  Aisle + Page index |"
+    );
+    for (i, times) in unordered.iter().enumerate() {
+        println!(
+            "|{:>6}M    |   {:>12.4}    |{:>12.4} |\t{:>12.4}\t    |\t{:>12.4}\t  |",
+            2_u32.pow(i as u32),
+            times[0],
+            times[1],
+            times[2],
+            times[3]
+        );
+    }
+    println!(
+        "+-----------------------------------------------------------------------------------------+"
+    );
+}

--- a/benches/reader.rs
+++ b/benches/reader.rs
@@ -1,0 +1,273 @@
+use std::sync::Arc;
+
+use aisle::{
+    ProjectionMask,
+    predicate::AislePredicate,
+    reader::{ParquetRecordBatchStreamBuilder, predicate::AislePredicateFn},
+};
+use arrow::{
+    array::{ArrayRef, Datum, RecordBatch, StringArray, UInt8Array, UInt64Array},
+    datatypes::{DataType, Field, Schema},
+};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use fusio::{DynFs, disk::TokioFs, fs::OpenOptions, path::Path};
+use fusio_parquet::{reader::AsyncReader, writer::AsyncWriter};
+use futures_util::StreamExt;
+use parquet::{
+    arrow::{
+        AsyncArrowWriter,
+        arrow_reader::{ArrowPredicate, ArrowPredicateFn, ArrowReaderOptions},
+    },
+    basic::Compression,
+    file::properties::{EnabledStatistics, WriterProperties},
+    format::SortingColumn,
+    schema::types::ColumnPath,
+};
+use rand::{Rng, thread_rng};
+
+fn get_ordered_record_batch(record_size: usize) -> RecordBatch {
+    let mut ids = vec![];
+    let mut ages = vec![];
+    let mut names = vec![];
+    for i in 0..record_size {
+        ids.push(i as u64);
+        ages.push((i % 256) as u8);
+        names.push(format!("{:08}", i));
+    }
+    RecordBatch::try_from_iter(vec![
+        ("id", Arc::new(UInt64Array::from(ids)) as ArrayRef),
+        ("name", Arc::new(StringArray::from(names)) as ArrayRef),
+        ("age", Arc::new(UInt8Array::from(ages)) as ArrayRef),
+    ])
+    .unwrap()
+}
+
+fn get_random_record_batch(record_size: usize) -> RecordBatch {
+    let mut ids = vec![];
+    let mut ages = vec![];
+    let mut names = vec![];
+    let mut rng = thread_rng();
+    for i in 0..record_size {
+        ids.push(rng.gen_range(0..record_size) as u64);
+        ages.push((rng.gen_range(0..record_size) % 256) as u8);
+        names.push(format!("{:08}", rng.gen_range(0..record_size * 10 + i)));
+    }
+    RecordBatch::try_from_iter(vec![
+        ("id", Arc::new(UInt64Array::from(ids)) as ArrayRef),
+        ("name", Arc::new(StringArray::from(names)) as ArrayRef),
+        ("age", Arc::new(UInt8Array::from(ages)) as ArrayRef),
+    ])
+    .unwrap()
+}
+
+async fn prepare_test_file(record_size: usize, sorted: bool) -> Path {
+    let dir = "./bench_data";
+    let filename = format!(
+        "bench_{}_{}.parquet",
+        sorted.then_some("sorted").unwrap_or("random"),
+        record_size
+    );
+
+    if !std::path::Path::new(dir).exists() {
+        std::fs::create_dir_all(dir).unwrap();
+    }
+
+    let path = Path::new(dir).unwrap().child(filename.as_str());
+
+    if !std::path::Path::new(&format!("{}/{}", dir, filename)).exists() {
+        let fs = Arc::new(TokioFs {}) as Arc<dyn DynFs>;
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::UInt64, false),
+            Field::new("name", DataType::Utf8, false),
+            Field::new("age", DataType::UInt8, false),
+        ]));
+
+        let mut properties_builder = WriterProperties::builder().set_compression(Compression::LZ4);
+        if sorted {
+            let column_paths = ColumnPath::new(vec!["id".into()]);
+            let sorting_columns = vec![SortingColumn::new(0, true, true)];
+            properties_builder = properties_builder
+                .set_column_bloom_filter_enabled(column_paths.clone(), true)
+                .set_column_statistics_enabled(column_paths, EnabledStatistics::Page)
+                .set_sorting_columns(Some(sorting_columns));
+        }
+        let mut writer = AsyncArrowWriter::try_new(
+            AsyncWriter::new(
+                fs.open_options(&path, OpenOptions::default().create(true).write(true))
+                    .await
+                    .unwrap(),
+            ),
+            schema,
+            Some(properties_builder.build()),
+        )
+        .unwrap();
+
+        let record_batch = if sorted {
+            get_ordered_record_batch(record_size)
+        } else {
+            get_random_record_batch(record_size)
+        };
+        writer.write(&record_batch).await.unwrap();
+        writer.close().await.unwrap();
+    }
+
+    path
+}
+
+async fn get_async_reader(path: &Path) -> AsyncReader {
+    let fs = Arc::new(TokioFs {});
+    let file = fs
+        .open_options(path, OpenOptions::default().read(true))
+        .await
+        .unwrap();
+    let size = file.size().await.unwrap();
+    AsyncReader::new(file, size).await.unwrap()
+}
+
+async fn bench_standard_reader(path: &Path, range: (u64, u64), options: ArrowReaderOptions) {
+    use arrow::compute::kernels::cmp::{gt, lt};
+    use parquet::arrow::arrow_reader::RowFilter;
+
+    let reader = get_async_reader(path).await;
+
+    let builder =
+        parquet::arrow::ParquetRecordBatchStreamBuilder::new_with_options(reader, options)
+            .await
+            .unwrap();
+    let parquet_schema = builder.parquet_schema();
+
+    let left_range_p = ArrowPredicateFn::new(
+        ProjectionMask::roots(parquet_schema, vec![0]),
+        move |batch| {
+            let datum = Arc::new(UInt64Array::new_scalar(range.0)) as Arc<dyn Datum>;
+            gt(batch.column(0), datum.as_ref())
+        },
+    );
+    let right_range_p = ArrowPredicateFn::new(
+        ProjectionMask::roots(parquet_schema, vec![0]),
+        move |batch| {
+            let datum = Arc::new(UInt64Array::new_scalar(range.1)) as Arc<dyn Datum>;
+            lt(batch.column(0), datum.as_ref())
+        },
+    );
+
+    let predicates: Vec<Box<dyn ArrowPredicate>> =
+        vec![Box::new(left_range_p), Box::new(right_range_p)];
+    let mut reader = builder
+        .with_row_filter(RowFilter::new(predicates).into())
+        .build()
+        .unwrap();
+
+    while let Some(_) = reader.next().await {}
+}
+
+async fn bench_pushdown_reader(path: &Path, range: (u64, u64), options: ArrowReaderOptions) {
+    use aisle::{
+        filter::RowFilter,
+        ord::{gt, lt},
+    };
+
+    let reader = get_async_reader(path).await;
+
+    let builder = ParquetRecordBatchStreamBuilder::new_with_options(reader, options)
+        .await
+        .unwrap();
+    let parquet_schema = builder.parquet_schema();
+
+    let left_range_p = AislePredicateFn::new(
+        ProjectionMask::roots(parquet_schema, vec![0]),
+        move |batch| {
+            let datum = Arc::new(UInt64Array::new_scalar(range.0)) as Arc<dyn Datum>;
+            gt(batch.column(0), datum.as_ref())
+        },
+    );
+    let right_range_p = AislePredicateFn::new(
+        ProjectionMask::roots(parquet_schema, vec![0]),
+        move |batch| {
+            let datum = Arc::new(UInt64Array::new_scalar(range.1)) as Arc<dyn Datum>;
+            lt(batch.column(0), datum.as_ref())
+        },
+    );
+
+    let predicates: Vec<Box<dyn AislePredicate>> =
+        vec![Box::new(left_range_p), Box::new(right_range_p)];
+    let mut reader = builder
+        .with_row_filter(RowFilter::new(predicates))
+        .build()
+        .unwrap();
+
+    while let Some(_) = reader.next().await {}
+}
+
+fn bench_compare_readers(c: &mut Criterion, group_name: &str, sorted: bool, with_page_index: bool) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    let sizes = vec![
+        1024 * 1024,
+        4 * 1024 * 1024,
+        8 * 1024 * 1024,
+        16 * 1024 * 1024,
+    ];
+    let mut group = c.benchmark_group(group_name);
+    for size in sizes {
+        let path = rt.block_on(prepare_test_file(size, sorted));
+
+        group.bench_with_input(
+            BenchmarkId::new("parquet_reader", size),
+            &size,
+            |b, &size| {
+                b.to_async(&rt).iter(|| async {
+                    let mut rng = thread_rng();
+                    let left = rng.gen_range(0..size);
+                    let right = rng.gen_range(left..size);
+                    bench_standard_reader(
+                        &path,
+                        (left as u64, right as u64),
+                        ArrowReaderOptions::new().with_page_index(with_page_index),
+                    )
+                    .await
+                });
+            },
+        );
+
+        group.bench_with_input(BenchmarkId::new("aisle_reader", size), &size, |b, &size| {
+            b.to_async(&rt).iter(|| async {
+                let mut rng = thread_rng();
+                let left = rng.gen_range(0..size);
+                let right = rng.gen_range(left..size);
+                bench_pushdown_reader(
+                    &path,
+                    (left as u64, right as u64),
+                    ArrowReaderOptions::new().with_page_index(with_page_index),
+                )
+                .await
+            });
+        });
+    }
+    group.finish();
+}
+
+fn compare_readers_sorted_without_page_index(c: &mut Criterion) {
+    bench_compare_readers(c, "sorted_without_page_index", true, false);
+}
+
+fn compare_readers_sorted_with_page_index(c: &mut Criterion) {
+    bench_compare_readers(c, "sorted_with_page_index", true, true);
+}
+
+fn compare_readers_random_without_page_index(c: &mut Criterion) {
+    bench_compare_readers(c, "random_without_page_index", false, false);
+}
+
+fn compare_readers_random_with_page_index(c: &mut Criterion) {
+    bench_compare_readers(c, "random_with_page_index", false, true);
+}
+
+criterion_group!(
+    benches,
+    compare_readers_sorted_without_page_index,
+    compare_readers_random_without_page_index,
+    compare_readers_sorted_with_page_index,
+    compare_readers_random_with_page_index,
+);
+criterion_main!(benches);

--- a/examples/reader.rs
+++ b/examples/reader.rs
@@ -1,0 +1,62 @@
+use std::sync::Arc;
+
+use aisle::{
+    ArrowReaderOptions, ParquetRecordBatchStreamBuilder, ProjectionMask,
+    filter::RowFilter,
+    ord::{gt, lt},
+    predicate::{AislePredicate, AislePredicateFn},
+};
+use arrow::array::{Datum, UInt64Array};
+use fusio::{DynFs, disk::TokioFs, fs::OpenOptions, path::Path};
+use fusio_parquet::reader::AsyncReader;
+use futures_util::StreamExt;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let fs = TokioFs {};
+    let file = fs
+        .open_options(
+            &Path::new("./data/data.parquet").unwrap(),
+            OpenOptions::default().read(true),
+        )
+        .await?;
+    let size = file.size().await.unwrap();
+    let reader = AsyncReader::new(file, size).await.unwrap();
+
+    let builder = ParquetRecordBatchStreamBuilder::new_with_options(
+        reader,
+        ArrowReaderOptions::new().with_page_index(true),
+    )
+    .await?;
+    // Create a predicates for filtering
+    let parquet_schema = builder.parquet_schema();
+    let filters: Vec<Box<dyn AislePredicate>> = vec![
+        Box::new(AislePredicateFn::new(
+            ProjectionMask::roots(parquet_schema, vec![0]),
+            |batch| {
+                let key = Arc::new(UInt64Array::new_scalar(1024)) as Arc<dyn Datum>;
+                gt(batch.column(0), key.as_ref())
+            },
+        )),
+        Box::new(AislePredicateFn::new(
+            ProjectionMask::roots(parquet_schema, vec![0]),
+            |batch| {
+                let key = Arc::new(UInt64Array::new_scalar(1050)) as Arc<dyn Datum>;
+                lt(batch.column(0), key.as_ref())
+            },
+        )),
+    ];
+
+    let mut stream = builder
+        .with_row_filter(RowFilter::new(filters))
+        .with_limit(10)
+        .with_projection(ProjectionMask::all())
+        .build()?;
+    while let Some(batch_result) = stream.next().await {
+        let batch = batch_result?;
+        println!("batch: {:?}", batch);
+        // Process your filtered record batch
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
- add usage example
- add benchmark

Here is the result of benchmark([read_bench](https://github.com/tonbo-io/aisle/compare/feat/bench?expand=1#diff-e8994dd8ed3c08c71ac17247d547ccac3be387333431343fdaf1eae2032f4c13R203)):

```
		read ordered data (time in milliseconds)		
+-----------------------------------------------------------------------------------------+
|num records|      Parquet      |    Aisle    |Parquet + Page index |  Aisle + Page index |
|     1M    |        10.1944    |      9.9352 |	      9.1019	    |	      6.2315	  |
|     2M    |        19.0694    |     15.7283 |	     17.5780	    |	     11.1676	  |
|     4M    |        35.8168    |     26.0524 |	     33.5340	    |	     20.6283	  |
|     8M    |        70.7043    |     45.9785 |	     66.0591	    |	     39.6452	  |
|    16M    |       134.5108    |     80.9409 |	    126.7634	    |	     73.2258	  |
|    32M    |       274.5309    |    164.4259 |	    255.6728	    |	    152.6481	  |
+-----------------------------------------------------------------------------------------+

parquet file size about 10M, 20M, 40M, 80M, 160M, 324M
```

```
		read totally random data (time in milliseconds)		
+-----------------------------------------------------------------------------------------+
|num records|      Parquet      |    Aisle    |Parquet + Page index |  Aisle + Page index |
|     1M    |        39.0727    |     39.0636 |	     38.7909	    |	     40.2455	  |
|     2M    |        80.3776    |     80.0867 |	     80.1276	    |	     82.6786	  |
|     4M    |       163.0556    |    162.6429 |	    163.3651	    |	    167.3413	  |
|     8M    |       315.1676    |    315.2757 |	    316.2162	    |	    324.1622	  |
|    16M    |       682.9139    |    679.8742 |	    679.1854	    |	    699.1987	  |
|    32M    |      1310.9390    |   1300.8780 |	   1305.4085	    |	   1319.1280	  |
+-----------------------------------------------------------------------------------------+

parquet file size about 14M, 30M, 60M, 125M, 256M, 532M
```