### PR TITLE
Add IntervalMonthDayNano support and safe interval ordering subset

### DIFF
--- a/tests/interval_support.rs
+++ b/tests/interval_support.rs
@@ -1,17 +1,17 @@
 use std::sync::Arc;
 
 use aisle::{Expr, PruneRequest};
-use arrow_buffer::IntervalDayTime;
+use arrow_buffer::{IntervalDayTime, IntervalMonthDayNano};
 use arrow_schema::{DataType, Field, IntervalUnit, Schema};
 use datafusion_common::ScalarValue;
 use parquet::{
     basic::{BoundaryOrder, ColumnOrder, Type as PhysicalType},
     data_type::FixedLenByteArray,
     file::metadata::{
-        ColumnChunkMetaData, ColumnIndexBuilder, FileMetaData, OffsetIndexBuilder,
-        ParquetMetaData, ParquetMetaDataBuilder, RowGroupMetaData,
+        ColumnChunkMetaData, ColumnIndexBuilder, FileMetaData, OffsetIndexBuilder, ParquetMetaData,
+        ParquetMetaDataBuilder, RowGroupMetaData,
     },
-    file::statistics::Statistics,
+    file::statistics::{Statistics, ValueStatistics},
     schema::{parser::parse_message_type, types::SchemaDescriptor},
 };
 
@@ -26,6 +26,22 @@ fn interval_day_time_bytes(days: i32, millis: i32) -> Vec<u8> {
     bytes[4..8].copy_from_slice(&days.to_le_bytes());
     bytes[8..12].copy_from_slice(&millis.to_le_bytes());
     bytes.to_vec()
+}
+
+fn interval_month_day_nano_bytes(months: i32, days: i32, millis: i32) -> Vec<u8> {
+    let mut bytes = [0u8; 12];
+    bytes[0..4].copy_from_slice(&months.to_le_bytes());
+    bytes[4..8].copy_from_slice(&days.to_le_bytes());
+    bytes[8..12].copy_from_slice(&millis.to_le_bytes());
+    bytes.to_vec()
+}
+
+fn interval_month_day_nano_scalar(months: i32, days: i32, millis: i32) -> ScalarValue {
+    ScalarValue::IntervalMonthDayNano(Some(IntervalMonthDayNano::new(
+        months,
+        days,
+        i64::from(millis) * 1_000_000,
+    )))
 }
 
 fn file_metadata(schema_descr: Arc<SchemaDescriptor>, num_rows: i64) -> FileMetaData {
@@ -56,13 +72,29 @@ fn interval_row_group_metadata(
     max: Vec<u8>,
     num_rows: i64,
 ) -> RowGroupMetaData {
+    interval_row_group_metadata_with_options(schema_descr, min, max, num_rows, Some(0), true, true)
+}
+
+fn interval_row_group_metadata_with_options(
+    schema_descr: &Arc<SchemaDescriptor>,
+    min: Vec<u8>,
+    max: Vec<u8>,
+    num_rows: i64,
+    null_count: Option<u64>,
+    min_is_exact: bool,
+    max_is_exact: bool,
+) -> RowGroupMetaData {
     let col_descr = schema_descr.column(0);
-    let stats = Statistics::fixed_len_byte_array(
-        Some(FixedLenByteArray::from(min)),
-        Some(FixedLenByteArray::from(max)),
-        None,
-        Some(0),
-        false,
+    let stats = Statistics::FixedLenByteArray(
+        ValueStatistics::new(
+            Some(FixedLenByteArray::from(min)),
+            Some(FixedLenByteArray::from(max)),
+            None,
+            null_count,
+            false,
+        )
+        .with_min_is_exact(min_is_exact)
+        .with_max_is_exact(max_is_exact),
     );
     let column = ColumnChunkMetaData::builder(col_descr.clone())
         .set_statistics(stats)
@@ -84,10 +116,38 @@ fn build_interval_page_metadata(
     row_group_min: Vec<u8>,
     row_group_max: Vec<u8>,
 ) -> ParquetMetaData {
+    build_interval_page_metadata_with_options(
+        page_min,
+        page_max,
+        row_group_min,
+        row_group_max,
+        Some(0),
+        true,
+        true,
+    )
+}
+
+fn build_interval_page_metadata_with_options(
+    page_min: Vec<Vec<u8>>,
+    page_max: Vec<Vec<u8>>,
+    row_group_min: Vec<u8>,
+    row_group_max: Vec<u8>,
+    row_group_null_count: Option<u64>,
+    row_group_min_is_exact: bool,
+    row_group_max_is_exact: bool,
+) -> ParquetMetaData {
     let schema_descr = schema_descriptor();
     let num_rows = page_min.len() as i64;
 
-    let row_group = interval_row_group_metadata(&schema_descr, row_group_min, row_group_max, num_rows);
+    let row_group = interval_row_group_metadata_with_options(
+        &schema_descr,
+        row_group_min,
+        row_group_max,
+        num_rows,
+        row_group_null_count,
+        row_group_min_is_exact,
+        row_group_max_is_exact,
+    );
     let file_meta = file_metadata(schema_descr.clone(), num_rows);
 
     let mut column_index = ColumnIndexBuilder::new(PhysicalType::FIXED_LEN_BYTE_ARRAY);
@@ -107,6 +167,15 @@ fn build_interval_page_metadata(
         .set_column_index(Some(vec![vec![column_index.build().unwrap()]]))
         .set_offset_index(Some(vec![vec![offset_index.build()]]))
         .build()
+}
+
+fn assert_has_page_skips(result: &aisle::PruneResult) {
+    let selection = result.row_selection().expect("expected page selection");
+    let selectors: Vec<parquet::arrow::arrow_reader::RowSelector> = selection.clone().into();
+    assert!(
+        selectors.iter().any(|sel| sel.skip),
+        "expected page selection with skips"
+    );
 }
 
 #[test]
@@ -183,6 +252,252 @@ fn row_group_prunes_interval_day_time_not_eq() {
 }
 
 #[test]
+fn row_group_prunes_interval_month_day_nano_not_eq() {
+    let schema = Schema::new(vec![Field::new(
+        "interval",
+        DataType::Interval(IntervalUnit::MonthDayNano),
+        false,
+    )]);
+
+    let schema_descr = schema_descriptor();
+    let row_group_0 = interval_row_group_metadata(
+        &schema_descr,
+        interval_month_day_nano_bytes(1, 2, 3),
+        interval_month_day_nano_bytes(1, 2, 3),
+        3,
+    );
+    let row_group_1 = interval_row_group_metadata(
+        &schema_descr,
+        interval_month_day_nano_bytes(2, 0, 0),
+        interval_month_day_nano_bytes(2, 0, 0),
+        3,
+    );
+
+    let file_meta = file_metadata(schema_descr.clone(), 6);
+    let metadata = ParquetMetaDataBuilder::new(file_meta)
+        .set_row_groups(vec![row_group_0, row_group_1])
+        .build();
+
+    let expr = Expr::not_eq("interval", interval_month_day_nano_scalar(1, 2, 3));
+    let result = PruneRequest::new(&metadata, &schema)
+        .with_predicate(&expr)
+        .enable_page_index(false)
+        .prune();
+
+    assert_eq!(result.row_groups(), &[1]);
+}
+
+#[test]
+fn row_group_prunes_interval_year_month_lt_with_exact_point_stats() {
+    let schema = Schema::new(vec![Field::new(
+        "interval",
+        DataType::Interval(IntervalUnit::YearMonth),
+        false,
+    )]);
+
+    let schema_descr = schema_descriptor();
+    let row_group_0 = interval_row_group_metadata(
+        &schema_descr,
+        interval_year_month_bytes(4),
+        interval_year_month_bytes(4),
+        3,
+    );
+    let row_group_1 = interval_row_group_metadata(
+        &schema_descr,
+        interval_year_month_bytes(8),
+        interval_year_month_bytes(8),
+        3,
+    );
+
+    let file_meta = file_metadata(schema_descr.clone(), 6);
+    let metadata = ParquetMetaDataBuilder::new(file_meta)
+        .set_row_groups(vec![row_group_0, row_group_1])
+        .build();
+
+    let expr = Expr::lt("interval", ScalarValue::IntervalYearMonth(Some(7)));
+    let result = PruneRequest::new(&metadata, &schema)
+        .with_predicate(&expr)
+        .enable_page_index(false)
+        .prune();
+
+    assert_eq!(result.row_groups(), &[0]);
+}
+
+#[test]
+fn row_group_prunes_interval_day_time_gt_eq_with_exact_point_stats() {
+    let schema = Schema::new(vec![Field::new(
+        "interval",
+        DataType::Interval(IntervalUnit::DayTime),
+        false,
+    )]);
+
+    let schema_descr = schema_descriptor();
+    let row_group_0 = interval_row_group_metadata(
+        &schema_descr,
+        interval_day_time_bytes(1, 0),
+        interval_day_time_bytes(1, 0),
+        3,
+    );
+    let row_group_1 = interval_row_group_metadata(
+        &schema_descr,
+        interval_day_time_bytes(3, 0),
+        interval_day_time_bytes(3, 0),
+        3,
+    );
+
+    let file_meta = file_metadata(schema_descr.clone(), 6);
+    let metadata = ParquetMetaDataBuilder::new(file_meta)
+        .set_row_groups(vec![row_group_0, row_group_1])
+        .build();
+
+    let value = IntervalDayTime::new(2, 0);
+    let expr = Expr::gt_eq("interval", ScalarValue::IntervalDayTime(Some(value)));
+    let result = PruneRequest::new(&metadata, &schema)
+        .with_predicate(&expr)
+        .enable_page_index(false)
+        .prune();
+
+    assert_eq!(result.row_groups(), &[1]);
+}
+
+#[test]
+fn row_group_prunes_interval_month_day_nano_lt_with_exact_point_stats() {
+    let schema = Schema::new(vec![Field::new(
+        "interval",
+        DataType::Interval(IntervalUnit::MonthDayNano),
+        false,
+    )]);
+
+    let schema_descr = schema_descriptor();
+    let row_group_0 = interval_row_group_metadata(
+        &schema_descr,
+        interval_month_day_nano_bytes(0, 10, 0),
+        interval_month_day_nano_bytes(0, 10, 0),
+        3,
+    );
+    let row_group_1 = interval_row_group_metadata(
+        &schema_descr,
+        interval_month_day_nano_bytes(2, 0, 0),
+        interval_month_day_nano_bytes(2, 0, 0),
+        3,
+    );
+
+    let file_meta = file_metadata(schema_descr.clone(), 6);
+    let metadata = ParquetMetaDataBuilder::new(file_meta)
+        .set_row_groups(vec![row_group_0, row_group_1])
+        .build();
+
+    let expr = Expr::lt("interval", interval_month_day_nano_scalar(1, 0, 0));
+    let result = PruneRequest::new(&metadata, &schema)
+        .with_predicate(&expr)
+        .enable_page_index(false)
+        .prune();
+
+    assert_eq!(result.row_groups(), &[0]);
+}
+
+#[test]
+fn row_group_interval_ordering_with_nulls_is_conservative() {
+    let schema = Schema::new(vec![Field::new(
+        "interval",
+        DataType::Interval(IntervalUnit::YearMonth),
+        true,
+    )]);
+
+    let schema_descr = schema_descriptor();
+    let row_group = interval_row_group_metadata_with_options(
+        &schema_descr,
+        interval_year_month_bytes(4),
+        interval_year_month_bytes(4),
+        3,
+        Some(1),
+        true,
+        true,
+    );
+
+    let file_meta = file_metadata(schema_descr.clone(), 3);
+    let metadata = ParquetMetaDataBuilder::new(file_meta)
+        .set_row_groups(vec![row_group])
+        .build();
+
+    let expr = Expr::lt("interval", ScalarValue::IntervalYearMonth(Some(7)));
+    let result = PruneRequest::new(&metadata, &schema)
+        .with_predicate(&expr)
+        .enable_page_index(false)
+        .prune();
+
+    // Unknown -> keep the row group.
+    assert_eq!(result.row_groups(), &[0]);
+}
+
+#[test]
+fn row_group_interval_ordering_mixed_variants_is_conservative() {
+    let schema = Schema::new(vec![Field::new(
+        "interval",
+        DataType::Interval(IntervalUnit::YearMonth),
+        false,
+    )]);
+
+    let schema_descr = schema_descriptor();
+    let row_group = interval_row_group_metadata(
+        &schema_descr,
+        interval_year_month_bytes(4),
+        interval_year_month_bytes(4),
+        3,
+    );
+
+    let file_meta = file_metadata(schema_descr.clone(), 3);
+    let metadata = ParquetMetaDataBuilder::new(file_meta)
+        .set_row_groups(vec![row_group])
+        .build();
+
+    let expr = Expr::lt(
+        "interval",
+        ScalarValue::IntervalDayTime(Some(IntervalDayTime::new(0, 1))),
+    );
+    let result = PruneRequest::new(&metadata, &schema)
+        .with_predicate(&expr)
+        .enable_page_index(false)
+        .prune();
+
+    // Mixed interval variants are not safely comparable for pruning.
+    assert_eq!(result.row_groups(), &[0]);
+}
+
+#[test]
+fn row_group_interval_ordering_requires_exact_stats() {
+    let schema = Schema::new(vec![Field::new(
+        "interval",
+        DataType::Interval(IntervalUnit::YearMonth),
+        false,
+    )]);
+
+    let schema_descr = schema_descriptor();
+    let row_group = interval_row_group_metadata_with_options(
+        &schema_descr,
+        interval_year_month_bytes(1),
+        interval_year_month_bytes(1),
+        3,
+        Some(0),
+        false,
+        false,
+    );
+
+    let file_meta = file_metadata(schema_descr.clone(), 3);
+    let metadata = ParquetMetaDataBuilder::new(file_meta)
+        .set_row_groups(vec![row_group])
+        .build();
+
+    let expr = Expr::lt("interval", ScalarValue::IntervalYearMonth(Some(2)));
+    let result = PruneRequest::new(&metadata, &schema)
+        .with_predicate(&expr)
+        .enable_page_index(false)
+        .prune();
+
+    assert_eq!(result.row_groups(), &[0]);
+}
+
+#[test]
 fn page_level_prunes_interval_year_month_pages() {
     let schema = Schema::new(vec![Field::new(
         "interval",
@@ -215,12 +530,7 @@ fn page_level_prunes_interval_year_month_pages() {
         .prune();
 
     assert_eq!(result.row_groups(), &[0]);
-    let selection = result.row_selection().expect("expected page selection");
-    let selectors: Vec<parquet::arrow::arrow_reader::RowSelector> = selection.clone().into();
-    assert!(
-        selectors.iter().any(|sel| sel.skip),
-        "expected page selection with skips"
-    );
+    assert_has_page_skips(&result);
 }
 
 #[test]
@@ -257,10 +567,79 @@ fn page_level_prunes_interval_day_time_pages() {
         .prune();
 
     assert_eq!(result.row_groups(), &[0]);
-    let selection = result.row_selection().expect("expected page selection");
-    let selectors: Vec<parquet::arrow::arrow_reader::RowSelector> = selection.clone().into();
-    assert!(
-        selectors.iter().any(|sel| sel.skip),
-        "expected page selection with skips"
+    assert_has_page_skips(&result);
+}
+
+#[test]
+fn page_level_prunes_interval_month_day_nano_pages() {
+    let schema = Schema::new(vec![Field::new(
+        "interval",
+        DataType::Interval(IntervalUnit::MonthDayNano),
+        false,
+    )]);
+
+    let metadata = build_interval_page_metadata(
+        vec![
+            interval_month_day_nano_bytes(0, 1, 0),
+            interval_month_day_nano_bytes(0, 2, 0),
+            interval_month_day_nano_bytes(0, 3, 0),
+            interval_month_day_nano_bytes(0, 4, 0),
+        ],
+        vec![
+            interval_month_day_nano_bytes(0, 1, 0),
+            interval_month_day_nano_bytes(0, 2, 0),
+            interval_month_day_nano_bytes(0, 3, 0),
+            interval_month_day_nano_bytes(0, 4, 0),
+        ],
+        interval_month_day_nano_bytes(0, 1, 0),
+        interval_month_day_nano_bytes(0, 4, 0),
     );
+
+    let expr = Expr::lt("interval", interval_month_day_nano_scalar(0, 3, 0));
+    let result = PruneRequest::new(&metadata, &schema)
+        .with_predicate(&expr)
+        .enable_page_index(true)
+        .emit_roaring(false)
+        .prune();
+
+    assert_eq!(result.row_groups(), &[0]);
+    assert_has_page_skips(&result);
+}
+
+#[test]
+fn page_level_interval_ordering_requires_exact_row_group_stats() {
+    let schema = Schema::new(vec![Field::new(
+        "interval",
+        DataType::Interval(IntervalUnit::YearMonth),
+        false,
+    )]);
+
+    let metadata = build_interval_page_metadata_with_options(
+        vec![
+            interval_year_month_bytes(1),
+            interval_year_month_bytes(2),
+            interval_year_month_bytes(3),
+        ],
+        vec![
+            interval_year_month_bytes(1),
+            interval_year_month_bytes(2),
+            interval_year_month_bytes(3),
+        ],
+        interval_year_month_bytes(1),
+        interval_year_month_bytes(3),
+        Some(0),
+        false,
+        false,
+    );
+
+    let expr = Expr::lt("interval", ScalarValue::IntervalYearMonth(Some(2)));
+    let result = PruneRequest::new(&metadata, &schema)
+        .with_predicate(&expr)
+        .enable_page_index(true)
+        .emit_roaring(false)
+        .prune();
+
+    // Ordering pruning must stay conservative when row-group byte stats are not exact.
+    assert_eq!(result.row_groups(), &[0]);
+    assert!(result.row_selection().is_none());
 }


### PR DESCRIPTION
## Summary
- add IntervalMonthDayNano metadata decoding from Parquet INTERVAL bytes
- enable safe interval ordering pruning (`<`, `<=`, `>`, `>=`) for exact point stats (`min == max`)
- keep conservative fallback for ambiguous/unsupported interval ordering cases
- add integration and unit tests for YearMonth/DayTime/MonthDayNano including null/mixed-variant/exactness edges
- update README and development plan with explicit conservative-policy docs for unsupported logical types

## Validation
- cargo fmt
- cargo check
- cargo test -q

Closes #14
