### PR TITLE
This PR improves dictionary-hint provider performance paths and closes two correctness/safety gaps in cached dictionary evidence handling.

### DIFF
--- a/benches/df_compare/Cargo.toml
+++ b/benches/df_compare/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0.3"
 parquet = { version = "57.1.0", default-features = false, features = ["arrow", "async"] }
 rand = "0.8"
 tempfile = "3.15.0"
-tokio = { version = "1.42.0", features = ["rt-multi-thread", "fs"] }
+tokio = { version = "1.42.0", features = ["rt-multi-thread", "fs", "time"] }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }

--- a/benches/df_compare/README.md
+++ b/benches/df_compare/README.md
@@ -125,7 +125,24 @@ open benches/df_compare/target/criterion/report/index.html
 - **Purpose:** Isolate dictionary-hint opportunity on selective string equality predicates
 - **Data:** Wide row-group stats (`a_anchor`..`z_anchor`) with target value present in a subset of row groups
 - **Mode:** `enable_dictionary_hints(true)` with provider-supplied exact per-row-group hint evidence
-- **Key Metrics:** Latency, row groups/pages kept, rows read as decode proxy
+- **Provider strategy variants:** `no cache`, `batch only`, `batch + cache`
+- **Benchmark IDs:**
+  - `aisle_metadata_only_candidate` / `aisle_prune_plus_scan_candidate` (`no cache`, legacy-stable IDs)
+  - `aisle_metadata_only_batch_only` / `aisle_prune_plus_scan_batch_only`
+  - `aisle_metadata_only_batch_plus_cache` / `aisle_prune_plus_scan_batch_plus_cache`
+- **Key Metrics:** metadata-only latency, prune+scan latency, row groups/pages kept, rows read as decode proxy
+- **Latest provider optimization results:** `benches/df_compare/results/dictionary_hints_provider_optimization.md`
+
+### `dictionary_hints.rs` - Remote Simulation Mode
+- **Purpose:** Expose provider strategy impact under simulated remote store latency
+- **Latency model:** `base_rtt + per_item_cost` via async sleep in provider methods
+- **Data:** 8 dictionary-hinted string columns; predicate is AND equality across all hinted columns
+- **Provider strategy variants:** `no cache`, `batch only`, `batch + cache` (warm cache)
+- **Benchmark IDs:**
+  - `aisle_metadata_only_remote_no_cache` / `aisle_prune_plus_scan_remote_no_cache`
+  - `aisle_metadata_only_remote_batch_only` / `aisle_prune_plus_scan_remote_batch_only`
+  - `aisle_metadata_only_remote_batch_plus_cache` / `aisle_prune_plus_scan_remote_batch_plus_cache`
+  - `aisle_metadata_only_remote_batch_plus_cache_cold` / `aisle_prune_plus_scan_remote_batch_plus_cache_cold`
 
 ### `projection.rs` - Wide Schema Projection
 - **Purpose:** Measure projection impact on Aisle read path under wide schemas

--- a/benches/df_compare/benches/dictionary_hints.rs
+++ b/benches/df_compare/benches/dictionary_hints.rs
@@ -1,20 +1,24 @@
-use std::path::Path;
-use std::sync::Arc;
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    path::Path,
+    sync::Arc,
+    time::Duration,
+};
 
 use aisle::{
-    AsyncBloomFilterProvider, DictionaryHintEvidence, DictionaryHintValue, PruneRequest,
+    AsyncBloomFilterProvider, CachedDictionaryHintProvider, DictionaryHintEvidence,
+    DictionaryHintValue, PruneRequest, PruneResult,
 };
 use arrow_array::{Array, Int64Array, RecordBatch, StringArray};
 use arrow_schema::{DataType, Field, Schema};
 use bytes::Bytes;
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use datafusion_expr::{Expr, col, lit};
-use futures::StreamExt;
-use parquet::bloom_filter::Sbbf;
+use futures::{StreamExt, lock::Mutex as AsyncMutex};
+use parquet::arrow::ArrowWriter;
 use parquet::arrow::arrow_reader::{ArrowReaderOptions, RowSelection};
 use parquet::arrow::async_reader::AsyncFileReader;
-use parquet::arrow::{ArrowWriter, ParquetRecordBatchStreamBuilder};
+use parquet::bloom_filter::Sbbf;
 use parquet::file::metadata::{PageIndexPolicy, ParquetMetaData, ParquetMetaDataReader};
 use parquet::file::properties::{EnabledStatistics, WriterProperties};
 use rand::{SeedableRng, seq::SliceRandom};
@@ -36,6 +40,64 @@ struct ScenarioMetrics {
     total_rows: usize,
 }
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum ProviderMode {
+    NoCache,
+    BatchOnly,
+    BatchPlusCache,
+}
+
+impl ProviderMode {
+    const ALL: [Self; 3] = [Self::NoCache, Self::BatchOnly, Self::BatchPlusCache];
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::NoCache => "no cache",
+            Self::BatchOnly => "batch only",
+            Self::BatchPlusCache => "batch + cache",
+        }
+    }
+
+    fn metadata_bench_id(self) -> &'static str {
+        match self {
+            // Keep the original benchmark id stable for the "no cache" mode.
+            Self::NoCache => "aisle_metadata_only_candidate",
+            Self::BatchOnly => "aisle_metadata_only_batch_only",
+            Self::BatchPlusCache => "aisle_metadata_only_batch_plus_cache",
+        }
+    }
+
+    fn prune_scan_bench_id(self) -> &'static str {
+        match self {
+            // Keep the original benchmark id stable for the "no cache" mode.
+            Self::NoCache => "aisle_prune_plus_scan_candidate",
+            Self::BatchOnly => "aisle_prune_plus_scan_batch_only",
+            Self::BatchPlusCache => "aisle_prune_plus_scan_batch_plus_cache",
+        }
+    }
+
+    fn remote_metadata_bench_id(self) -> &'static str {
+        match self {
+            Self::NoCache => "aisle_metadata_only_remote_no_cache",
+            Self::BatchOnly => "aisle_metadata_only_remote_batch_only",
+            Self::BatchPlusCache => "aisle_metadata_only_remote_batch_plus_cache",
+        }
+    }
+
+    fn remote_prune_scan_bench_id(self) -> &'static str {
+        match self {
+            Self::NoCache => "aisle_prune_plus_scan_remote_no_cache",
+            Self::BatchOnly => "aisle_prune_plus_scan_remote_batch_only",
+            Self::BatchPlusCache => "aisle_prune_plus_scan_remote_batch_plus_cache",
+        }
+    }
+}
+
+const REMOTE_METADATA_BATCH_PLUS_CACHE_COLD_ID: &str =
+    "aisle_metadata_only_remote_batch_plus_cache_cold";
+const REMOTE_PRUNE_SCAN_BATCH_PLUS_CACHE_COLD_ID: &str =
+    "aisle_prune_plus_scan_remote_batch_plus_cache_cold";
+
 fn count_matches(batch: &RecordBatch, target_key: &str) -> usize {
     let array = batch
         .column(1)
@@ -49,7 +111,7 @@ fn count_matches(batch: &RecordBatch, target_key: &str) -> usize {
 }
 
 async fn scan_builder<T: AsyncFileReader + Unpin + Send + 'static>(
-    builder: ParquetRecordBatchStreamBuilder<T>,
+    builder: parquet::arrow::ParquetRecordBatchStreamBuilder<T>,
     row_groups: &[usize],
     row_selection: Option<RowSelection>,
     target_key: &str,
@@ -81,7 +143,7 @@ async fn scan_file_async(
 ) -> ScanStats {
     let file = tokio::fs::File::open(path).await.expect("open parquet");
     let options = ArrowReaderOptions::new().with_page_index(enable_page_index);
-    let builder = ParquetRecordBatchStreamBuilder::new_with_options(file, options)
+    let builder = parquet::arrow::ParquetRecordBatchStreamBuilder::new_with_options(file, options)
         .await
         .expect("stream builder");
     scan_builder(builder, row_groups, row_selection, target_key).await
@@ -159,6 +221,7 @@ fn create_dictionary_candidate_data(
             let next_common = common_values[(values.len() + row_group_idx) % common_values.len()];
             values.push(next_common.to_string());
         }
+
         let hint_values: HashSet<DictionaryHintValue> = values
             .iter()
             .cloned()
@@ -197,20 +260,129 @@ fn create_dictionary_candidate_data(
     (temp_file, metadata, schema, target_key, dictionary_hints)
 }
 
+fn create_dictionary_remote_sim_data(
+    row_groups: usize,
+    rows_per_group: usize,
+    key_columns: usize,
+) -> (
+    tempfile::NamedTempFile,
+    ParquetMetaData,
+    Arc<Schema>,
+    String,
+    Vec<String>,
+    HashMap<(usize, usize), HashSet<DictionaryHintValue>>,
+) {
+    let key_names: Vec<String> = (0..key_columns).map(|i| format!("key_{i:02}")).collect();
+    let mut fields = vec![Field::new("id", DataType::Int64, false)];
+    for key_name in &key_names {
+        fields.push(Field::new(key_name, DataType::Utf8, false));
+    }
+    let schema = Arc::new(Schema::new(fields));
+
+    let props = WriterProperties::builder()
+        .set_statistics_enabled(EnabledStatistics::Page)
+        .set_dictionary_enabled(true)
+        .set_max_row_group_size(rows_per_group)
+        .set_data_page_row_count_limit(512)
+        .build();
+
+    let target_key = "target_remote_07".to_string();
+    let common_values = [
+        "common_alpha",
+        "common_beta",
+        "common_gamma",
+        "common_delta",
+        "common_theta",
+        "common_lambda",
+    ];
+
+    let temp_file = tempfile::NamedTempFile::new().expect("temp file");
+    let file = std::fs::File::create(temp_file.path()).expect("create parquet");
+    let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props)).expect("arrow writer");
+    let mut dictionary_hints: HashMap<(usize, usize), HashSet<DictionaryHintValue>> =
+        HashMap::new();
+
+    let mut rng = rand::rngs::StdRng::seed_from_u64(17);
+
+    for row_group_idx in 0..row_groups {
+        let mut values = Vec::with_capacity(rows_per_group);
+        values.push("a_anchor".to_string());
+        values.push("z_anchor".to_string());
+
+        let has_target = row_group_idx % 8 == 3;
+        let target_repeats = if has_target { rows_per_group / 8 } else { 0 };
+        for _ in 0..target_repeats {
+            values.push(target_key.clone());
+        }
+
+        while values.len() < rows_per_group {
+            let next_common = common_values[(values.len() + row_group_idx) % common_values.len()];
+            values.push(next_common.to_string());
+        }
+
+        let hint_values: HashSet<DictionaryHintValue> = values
+            .iter()
+            .cloned()
+            .map(DictionaryHintValue::Utf8)
+            .collect();
+
+        let mut ids: Vec<i64> = (0..rows_per_group)
+            .map(|i| (row_group_idx * rows_per_group + i) as i64)
+            .collect();
+
+        let mut zipped: Vec<(i64, String)> = ids.drain(..).zip(values.into_iter()).collect();
+        zipped.shuffle(&mut rng);
+        let (ids, values): (Vec<i64>, Vec<String>) = zipped.into_iter().unzip();
+
+        let mut columns = Vec::with_capacity(1 + key_columns);
+        columns.push(Arc::new(Int64Array::from(ids)) as Arc<dyn Array>);
+        for key_col_idx in 0..key_columns {
+            columns.push(Arc::new(StringArray::from(values.clone())) as Arc<dyn Array>);
+            dictionary_hints.insert((row_group_idx, key_col_idx + 1), hint_values.clone());
+        }
+
+        let batch = RecordBatch::try_new(schema.clone(), columns).expect("record batch");
+        writer.write(&batch).expect("write row group");
+    }
+
+    writer.close().expect("close parquet writer");
+
+    let bytes = std::fs::read(temp_file.path()).expect("read parquet bytes");
+    let metadata = ParquetMetaDataReader::new()
+        .with_page_index_policy(PageIndexPolicy::Optional)
+        .parse_and_finish(&Bytes::from(bytes))
+        .expect("read metadata");
+
+    (
+        temp_file,
+        metadata,
+        schema,
+        target_key,
+        key_names,
+        dictionary_hints,
+    )
+}
+
+fn build_all_columns_eq_predicate(key_columns: &[String], target_key: &str) -> Expr {
+    let mut expr = col(&key_columns[0]).eq(lit(target_key.to_string()));
+    for key_column in &key_columns[1..] {
+        expr = expr.and(col(key_column).eq(lit(target_key.to_string())));
+    }
+    expr
+}
+
 #[derive(Clone)]
-struct StaticDictionaryHintProvider {
+struct NoCacheDictionaryHintProvider {
     hints: Arc<HashMap<(usize, usize), HashSet<DictionaryHintValue>>>,
 }
 
-impl StaticDictionaryHintProvider {
-    fn new(hints: HashMap<(usize, usize), HashSet<DictionaryHintValue>>) -> Self {
-        Self {
-            hints: Arc::new(hints),
-        }
+impl NoCacheDictionaryHintProvider {
+    fn new(hints: Arc<HashMap<(usize, usize), HashSet<DictionaryHintValue>>>) -> Self {
+        Self { hints }
     }
 }
 
-impl AsyncBloomFilterProvider for StaticDictionaryHintProvider {
+impl AsyncBloomFilterProvider for NoCacheDictionaryHintProvider {
     async fn bloom_filter(&mut self, _row_group_idx: usize, _column_idx: usize) -> Option<Sbbf> {
         None
     }
@@ -227,25 +399,182 @@ impl AsyncBloomFilterProvider for StaticDictionaryHintProvider {
     }
 }
 
-fn evaluate_metrics(
+#[derive(Clone)]
+struct BatchOnlyDictionaryHintProvider {
+    hints: Arc<HashMap<(usize, usize), HashSet<DictionaryHintValue>>>,
+}
+
+impl BatchOnlyDictionaryHintProvider {
+    fn new(hints: Arc<HashMap<(usize, usize), HashSet<DictionaryHintValue>>>) -> Self {
+        Self { hints }
+    }
+}
+
+impl AsyncBloomFilterProvider for BatchOnlyDictionaryHintProvider {
+    async fn bloom_filter(&mut self, _row_group_idx: usize, _column_idx: usize) -> Option<Sbbf> {
+        None
+    }
+
+    async fn dictionary_hints(
+        &mut self,
+        row_group_idx: usize,
+        column_idx: usize,
+    ) -> DictionaryHintEvidence {
+        match self.hints.get(&(row_group_idx, column_idx)) {
+            Some(values) => DictionaryHintEvidence::Exact(values.clone()),
+            None => DictionaryHintEvidence::Unknown,
+        }
+    }
+
+    async fn dictionary_hints_batch<'a>(
+        &'a mut self,
+        requests: &'a [(usize, usize)],
+    ) -> HashMap<(usize, usize), DictionaryHintEvidence> {
+        requests
+            .iter()
+            .map(|&(row_group_idx, column_idx)| {
+                let evidence = match self.hints.get(&(row_group_idx, column_idx)) {
+                    Some(values) => DictionaryHintEvidence::Exact(values.clone()),
+                    None => DictionaryHintEvidence::Unknown,
+                };
+                ((row_group_idx, column_idx), evidence)
+            })
+            .collect()
+    }
+}
+
+#[derive(Clone, Copy)]
+struct SimulatedRemoteLatency {
+    base_micros: u64,
+    per_item_micros: u64,
+}
+
+impl SimulatedRemoteLatency {
+    fn single_delay(self) -> Duration {
+        Duration::from_micros(self.base_micros + self.per_item_micros)
+    }
+
+    fn batch_delay(self, item_count: usize) -> Duration {
+        Duration::from_micros(
+            self.base_micros
+                .saturating_add(self.per_item_micros.saturating_mul(item_count as u64)),
+        )
+    }
+}
+
+#[derive(Clone)]
+struct SimNoCacheDictionaryHintProvider {
+    hints: Arc<HashMap<(usize, usize), HashSet<DictionaryHintValue>>>,
+    latency: SimulatedRemoteLatency,
+}
+
+impl SimNoCacheDictionaryHintProvider {
+    fn new(
+        hints: Arc<HashMap<(usize, usize), HashSet<DictionaryHintValue>>>,
+        latency: SimulatedRemoteLatency,
+    ) -> Self {
+        Self { hints, latency }
+    }
+}
+
+impl AsyncBloomFilterProvider for SimNoCacheDictionaryHintProvider {
+    async fn bloom_filter(&mut self, _row_group_idx: usize, _column_idx: usize) -> Option<Sbbf> {
+        None
+    }
+
+    async fn dictionary_hints(
+        &mut self,
+        row_group_idx: usize,
+        column_idx: usize,
+    ) -> DictionaryHintEvidence {
+        tokio::time::sleep(self.latency.single_delay()).await;
+        match self.hints.get(&(row_group_idx, column_idx)) {
+            Some(values) => DictionaryHintEvidence::Exact(values.clone()),
+            None => DictionaryHintEvidence::Unknown,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct SimBatchOnlyDictionaryHintProvider {
+    hints: Arc<HashMap<(usize, usize), HashSet<DictionaryHintValue>>>,
+    latency: SimulatedRemoteLatency,
+}
+
+impl SimBatchOnlyDictionaryHintProvider {
+    fn new(
+        hints: Arc<HashMap<(usize, usize), HashSet<DictionaryHintValue>>>,
+        latency: SimulatedRemoteLatency,
+    ) -> Self {
+        Self { hints, latency }
+    }
+}
+
+impl AsyncBloomFilterProvider for SimBatchOnlyDictionaryHintProvider {
+    async fn bloom_filter(&mut self, _row_group_idx: usize, _column_idx: usize) -> Option<Sbbf> {
+        None
+    }
+
+    async fn dictionary_hints(
+        &mut self,
+        row_group_idx: usize,
+        column_idx: usize,
+    ) -> DictionaryHintEvidence {
+        tokio::time::sleep(self.latency.single_delay()).await;
+        match self.hints.get(&(row_group_idx, column_idx)) {
+            Some(values) => DictionaryHintEvidence::Exact(values.clone()),
+            None => DictionaryHintEvidence::Unknown,
+        }
+    }
+
+    async fn dictionary_hints_batch<'a>(
+        &'a mut self,
+        requests: &'a [(usize, usize)],
+    ) -> HashMap<(usize, usize), DictionaryHintEvidence> {
+        tokio::time::sleep(self.latency.batch_delay(requests.len())).await;
+        requests
+            .iter()
+            .map(|&(row_group_idx, column_idx)| {
+                let evidence = match self.hints.get(&(row_group_idx, column_idx)) {
+                    Some(values) => DictionaryHintEvidence::Exact(values.clone()),
+                    None => DictionaryHintEvidence::Unknown,
+                };
+                ((row_group_idx, column_idx), evidence)
+            })
+            .collect()
+    }
+}
+
+async fn prune_with_provider<P: AsyncBloomFilterProvider>(
+    metadata: &ParquetMetaData,
+    schema: &Arc<Schema>,
+    predicate: &Expr,
+    provider: &mut P,
+) -> PruneResult {
+    PruneRequest::new(metadata, schema)
+        .with_df_predicate(predicate)
+        .enable_page_index(false)
+        .enable_bloom_filter(false)
+        .enable_dictionary_hints(true)
+        .prune_async(provider)
+        .await
+}
+
+fn evaluate_metrics_with_provider<P: AsyncBloomFilterProvider>(
     runtime: &tokio::runtime::Runtime,
     path: &Path,
     metadata: &ParquetMetaData,
     schema: &Arc<Schema>,
     predicate: &Expr,
     target_key: &str,
-    provider: StaticDictionaryHintProvider,
+    mut provider: P,
 ) -> ScenarioMetrics {
-    let mut provider = provider;
-    let result = runtime.block_on(async {
-        PruneRequest::new(metadata, schema)
-            .with_df_predicate(predicate)
-            .enable_page_index(false)
-            .enable_bloom_filter(false)
-            .enable_dictionary_hints(true)
-            .prune_async(&mut provider)
-            .await
-    });
+    let result = runtime.block_on(prune_with_provider(
+        metadata,
+        schema,
+        predicate,
+        &mut provider,
+    ));
 
     let kept_row_groups = result.row_groups().to_vec();
     let all_row_groups: Vec<usize> = (0..metadata.num_row_groups()).collect();
@@ -275,59 +604,447 @@ fn bench_dictionary_hints_candidate(c: &mut Criterion) {
     let rows_per_group = 2_048;
     let (temp_file, metadata, schema, target_key, dictionary_hints) =
         create_dictionary_candidate_data(row_groups, rows_per_group);
-    let provider_template = StaticDictionaryHintProvider::new(dictionary_hints);
+    let dictionary_hints = Arc::new(dictionary_hints);
 
     let predicate = col("key").eq(lit(target_key.clone()));
     let runtime = tokio::runtime::Runtime::new().expect("tokio runtime");
 
-    let metrics = evaluate_metrics(
-        &runtime,
-        temp_file.path(),
-        &metadata,
-        &schema,
-        &predicate,
-        &target_key,
-        provider_template.clone(),
-    );
+    for mode in ProviderMode::ALL {
+        let metrics = match mode {
+            ProviderMode::NoCache => evaluate_metrics_with_provider(
+                &runtime,
+                temp_file.path(),
+                &metadata,
+                &schema,
+                &predicate,
+                &target_key,
+                NoCacheDictionaryHintProvider::new(Arc::clone(&dictionary_hints)),
+            ),
+            ProviderMode::BatchOnly => evaluate_metrics_with_provider(
+                &runtime,
+                temp_file.path(),
+                &metadata,
+                &schema,
+                &predicate,
+                &target_key,
+                BatchOnlyDictionaryHintProvider::new(Arc::clone(&dictionary_hints)),
+            ),
+            ProviderMode::BatchPlusCache => evaluate_metrics_with_provider(
+                &runtime,
+                temp_file.path(),
+                &metadata,
+                &schema,
+                &predicate,
+                &target_key,
+                CachedDictionaryHintProvider::with_capacity(
+                    BatchOnlyDictionaryHintProvider::new(Arc::clone(&dictionary_hints)),
+                    metadata.num_row_groups(),
+                ),
+            ),
+        };
 
-    println!(
-        "Dictionary-hints candidate (enabled): query=key = '{}', row_groups_kept={}/{}, pages_kept={}/{}, rows_read={}, rows_matched={}, decode_proxy={:.1}%",
-        target_key,
-        metrics.row_groups_kept,
-        metrics.total_row_groups,
-        metrics.pages_kept,
-        metrics.total_pages,
-        metrics.rows_read,
-        metrics.rows_matched,
-        (metrics.rows_read as f64 / metrics.total_rows as f64) * 100.0
-    );
+        println!(
+            "Dictionary-hints candidate ({}) : query=key = '{}', row_groups_kept={}/{}, pages_kept={}/{}, rows_read={}, rows_matched={}, decode_proxy={:.1}%",
+            mode.label(),
+            target_key,
+            metrics.row_groups_kept,
+            metrics.total_row_groups,
+            metrics.pages_kept,
+            metrics.total_pages,
+            metrics.rows_read,
+            metrics.rows_matched,
+            (metrics.rows_read as f64 / metrics.total_rows as f64) * 100.0
+        );
+    }
 
     let mut group = c.benchmark_group("dictionary_hints_candidate");
 
-    group.bench_function("aisle_metadata_only_candidate", |b| {
+    group.bench_function(ProviderMode::NoCache.metadata_bench_id(), |b| {
         b.to_async(&runtime).iter(|| async {
-            let mut provider = provider_template.clone();
-            let result = PruneRequest::new(black_box(&metadata), black_box(&schema))
-                .with_df_predicate(black_box(&predicate))
-                .enable_page_index(false)
-                .enable_bloom_filter(false)
-                .enable_dictionary_hints(true)
-                .prune_async(&mut provider)
-                .await;
+            let mut provider = NoCacheDictionaryHintProvider::new(Arc::clone(&dictionary_hints));
+            let result = prune_with_provider(
+                black_box(&metadata),
+                black_box(&schema),
+                black_box(&predicate),
+                &mut provider,
+            )
+            .await;
             black_box(result.row_groups());
         });
     });
 
-    group.bench_function("aisle_prune_plus_scan_candidate", |b| {
+    group.bench_function(ProviderMode::NoCache.prune_scan_bench_id(), |b| {
         b.to_async(&runtime).iter(|| async {
-            let mut provider = provider_template.clone();
-            let result = PruneRequest::new(black_box(&metadata), black_box(&schema))
-                .with_df_predicate(black_box(&predicate))
-                .enable_page_index(false)
-                .enable_bloom_filter(false)
-                .enable_dictionary_hints(true)
-                .prune_async(&mut provider)
+            let mut provider = NoCacheDictionaryHintProvider::new(Arc::clone(&dictionary_hints));
+            let result = prune_with_provider(
+                black_box(&metadata),
+                black_box(&schema),
+                black_box(&predicate),
+                &mut provider,
+            )
+            .await;
+            let stats = scan_file_async(
+                temp_file.path(),
+                result.row_groups(),
+                None,
+                &target_key,
+                false,
+            )
+            .await;
+            black_box(stats);
+        });
+    });
+
+    group.bench_function(ProviderMode::BatchOnly.metadata_bench_id(), |b| {
+        b.to_async(&runtime).iter(|| async {
+            let mut provider = BatchOnlyDictionaryHintProvider::new(Arc::clone(&dictionary_hints));
+            let result = prune_with_provider(
+                black_box(&metadata),
+                black_box(&schema),
+                black_box(&predicate),
+                &mut provider,
+            )
+            .await;
+            black_box(result.row_groups());
+        });
+    });
+
+    group.bench_function(ProviderMode::BatchOnly.prune_scan_bench_id(), |b| {
+        b.to_async(&runtime).iter(|| async {
+            let mut provider = BatchOnlyDictionaryHintProvider::new(Arc::clone(&dictionary_hints));
+            let result = prune_with_provider(
+                black_box(&metadata),
+                black_box(&schema),
+                black_box(&predicate),
+                &mut provider,
+            )
+            .await;
+            let stats = scan_file_async(
+                temp_file.path(),
+                result.row_groups(),
+                None,
+                &target_key,
+                false,
+            )
+            .await;
+            black_box(stats);
+        });
+    });
+
+    let metadata_cached_provider = Arc::new(AsyncMutex::new(
+        CachedDictionaryHintProvider::with_capacity(
+            BatchOnlyDictionaryHintProvider::new(Arc::clone(&dictionary_hints)),
+            metadata.num_row_groups(),
+        ),
+    ));
+    runtime.block_on(async {
+        let mut provider = metadata_cached_provider.lock().await;
+        let _ = prune_with_provider(&metadata, &schema, &predicate, &mut *provider).await;
+    });
+    group.bench_function(ProviderMode::BatchPlusCache.metadata_bench_id(), |b| {
+        let provider = Arc::clone(&metadata_cached_provider);
+        let metadata = &metadata;
+        let schema = &schema;
+        let predicate = &predicate;
+        b.to_async(&runtime).iter(|| {
+            let provider = Arc::clone(&provider);
+            async move {
+                let mut provider = provider.lock().await;
+                let result = prune_with_provider(
+                    black_box(metadata),
+                    black_box(schema),
+                    black_box(predicate),
+                    &mut *provider,
+                )
                 .await;
+                black_box(result.row_groups());
+            }
+        });
+    });
+
+    let scan_cached_provider = Arc::new(AsyncMutex::new(
+        CachedDictionaryHintProvider::with_capacity(
+            BatchOnlyDictionaryHintProvider::new(Arc::clone(&dictionary_hints)),
+            metadata.num_row_groups(),
+        ),
+    ));
+    runtime.block_on(async {
+        let mut provider = scan_cached_provider.lock().await;
+        let _ = prune_with_provider(&metadata, &schema, &predicate, &mut *provider).await;
+    });
+    group.bench_function(ProviderMode::BatchPlusCache.prune_scan_bench_id(), |b| {
+        let provider = Arc::clone(&scan_cached_provider);
+        let metadata = &metadata;
+        let schema = &schema;
+        let predicate = &predicate;
+        let target_key = &target_key;
+        let path = temp_file.path().to_path_buf();
+        b.to_async(&runtime).iter(|| {
+            let provider = Arc::clone(&provider);
+            let path = path.clone();
+            async move {
+                let mut provider = provider.lock().await;
+                let result = prune_with_provider(
+                    black_box(metadata),
+                    black_box(schema),
+                    black_box(predicate),
+                    &mut *provider,
+                )
+                .await;
+                let stats =
+                    scan_file_async(&path, result.row_groups(), None, target_key, false).await;
+                black_box(stats);
+            }
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_dictionary_hints_remote_sim(c: &mut Criterion) {
+    let row_groups = 24;
+    let rows_per_group = 1_024;
+    let key_columns = 8;
+    let (temp_file, metadata, schema, target_key, key_names, dictionary_hints) =
+        create_dictionary_remote_sim_data(row_groups, rows_per_group, key_columns);
+    let dictionary_hints = Arc::new(dictionary_hints);
+
+    let predicate = build_all_columns_eq_predicate(&key_names, &target_key);
+    let runtime = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let latency = SimulatedRemoteLatency {
+        base_micros: 200,
+        per_item_micros: 30,
+    };
+
+    for mode in ProviderMode::ALL {
+        let metrics = match mode {
+            ProviderMode::NoCache => evaluate_metrics_with_provider(
+                &runtime,
+                temp_file.path(),
+                &metadata,
+                &schema,
+                &predicate,
+                &target_key,
+                SimNoCacheDictionaryHintProvider::new(Arc::clone(&dictionary_hints), latency),
+            ),
+            ProviderMode::BatchOnly => evaluate_metrics_with_provider(
+                &runtime,
+                temp_file.path(),
+                &metadata,
+                &schema,
+                &predicate,
+                &target_key,
+                SimBatchOnlyDictionaryHintProvider::new(Arc::clone(&dictionary_hints), latency),
+            ),
+            ProviderMode::BatchPlusCache => evaluate_metrics_with_provider(
+                &runtime,
+                temp_file.path(),
+                &metadata,
+                &schema,
+                &predicate,
+                &target_key,
+                CachedDictionaryHintProvider::with_capacity(
+                    SimBatchOnlyDictionaryHintProvider::new(Arc::clone(&dictionary_hints), latency),
+                    metadata.num_row_groups() * key_columns,
+                ),
+            ),
+        };
+
+        println!(
+            "Dictionary-hints remote-sim ({}) : query=ALL_KEYS = '{}', row_groups_kept={}/{}, pages_kept={}/{}, rows_read={}, rows_matched={}, decode_proxy={:.1}%",
+            mode.label(),
+            target_key,
+            metrics.row_groups_kept,
+            metrics.total_row_groups,
+            metrics.pages_kept,
+            metrics.total_pages,
+            metrics.rows_read,
+            metrics.rows_matched,
+            (metrics.rows_read as f64 / metrics.total_rows as f64) * 100.0
+        );
+    }
+
+    let mut group = c.benchmark_group("dictionary_hints_remote_sim");
+
+    group.bench_function(ProviderMode::NoCache.remote_metadata_bench_id(), |b| {
+        b.to_async(&runtime).iter(|| async {
+            let mut provider =
+                SimNoCacheDictionaryHintProvider::new(Arc::clone(&dictionary_hints), latency);
+            let result = prune_with_provider(
+                black_box(&metadata),
+                black_box(&schema),
+                black_box(&predicate),
+                &mut provider,
+            )
+            .await;
+            black_box(result.row_groups());
+        });
+    });
+
+    group.bench_function(ProviderMode::NoCache.remote_prune_scan_bench_id(), |b| {
+        b.to_async(&runtime).iter(|| async {
+            let mut provider =
+                SimNoCacheDictionaryHintProvider::new(Arc::clone(&dictionary_hints), latency);
+            let result = prune_with_provider(
+                black_box(&metadata),
+                black_box(&schema),
+                black_box(&predicate),
+                &mut provider,
+            )
+            .await;
+            let stats = scan_file_async(
+                temp_file.path(),
+                result.row_groups(),
+                None,
+                &target_key,
+                false,
+            )
+            .await;
+            black_box(stats);
+        });
+    });
+
+    group.bench_function(ProviderMode::BatchOnly.remote_metadata_bench_id(), |b| {
+        b.to_async(&runtime).iter(|| async {
+            let mut provider =
+                SimBatchOnlyDictionaryHintProvider::new(Arc::clone(&dictionary_hints), latency);
+            let result = prune_with_provider(
+                black_box(&metadata),
+                black_box(&schema),
+                black_box(&predicate),
+                &mut provider,
+            )
+            .await;
+            black_box(result.row_groups());
+        });
+    });
+
+    group.bench_function(ProviderMode::BatchOnly.remote_prune_scan_bench_id(), |b| {
+        b.to_async(&runtime).iter(|| async {
+            let mut provider =
+                SimBatchOnlyDictionaryHintProvider::new(Arc::clone(&dictionary_hints), latency);
+            let result = prune_with_provider(
+                black_box(&metadata),
+                black_box(&schema),
+                black_box(&predicate),
+                &mut provider,
+            )
+            .await;
+            let stats = scan_file_async(
+                temp_file.path(),
+                result.row_groups(),
+                None,
+                &target_key,
+                false,
+            )
+            .await;
+            black_box(stats);
+        });
+    });
+
+    let metadata_cached_provider = Arc::new(AsyncMutex::new(
+        CachedDictionaryHintProvider::with_capacity(
+            SimBatchOnlyDictionaryHintProvider::new(Arc::clone(&dictionary_hints), latency),
+            metadata.num_row_groups() * key_columns,
+        ),
+    ));
+    runtime.block_on(async {
+        let mut provider = metadata_cached_provider.lock().await;
+        let _ = prune_with_provider(&metadata, &schema, &predicate, &mut *provider).await;
+    });
+    group.bench_function(
+        ProviderMode::BatchPlusCache.remote_metadata_bench_id(),
+        |b| {
+            let provider = Arc::clone(&metadata_cached_provider);
+            let metadata = &metadata;
+            let schema = &schema;
+            let predicate = &predicate;
+            b.to_async(&runtime).iter(|| {
+                let provider = Arc::clone(&provider);
+                async move {
+                    let mut provider = provider.lock().await;
+                    let result = prune_with_provider(
+                        black_box(metadata),
+                        black_box(schema),
+                        black_box(predicate),
+                        &mut *provider,
+                    )
+                    .await;
+                    black_box(result.row_groups());
+                }
+            });
+        },
+    );
+
+    let scan_cached_provider = Arc::new(AsyncMutex::new(
+        CachedDictionaryHintProvider::with_capacity(
+            SimBatchOnlyDictionaryHintProvider::new(Arc::clone(&dictionary_hints), latency),
+            metadata.num_row_groups() * key_columns,
+        ),
+    ));
+    runtime.block_on(async {
+        let mut provider = scan_cached_provider.lock().await;
+        let _ = prune_with_provider(&metadata, &schema, &predicate, &mut *provider).await;
+    });
+    group.bench_function(
+        ProviderMode::BatchPlusCache.remote_prune_scan_bench_id(),
+        |b| {
+            let provider = Arc::clone(&scan_cached_provider);
+            let metadata = &metadata;
+            let schema = &schema;
+            let predicate = &predicate;
+            let target_key = &target_key;
+            let path = temp_file.path().to_path_buf();
+            b.to_async(&runtime).iter(|| {
+                let provider = Arc::clone(&provider);
+                let path = path.clone();
+                async move {
+                    let mut provider = provider.lock().await;
+                    let result = prune_with_provider(
+                        black_box(metadata),
+                        black_box(schema),
+                        black_box(predicate),
+                        &mut *provider,
+                    )
+                    .await;
+                    let stats =
+                        scan_file_async(&path, result.row_groups(), None, target_key, false).await;
+                    black_box(stats);
+                }
+            });
+        },
+    );
+
+    group.bench_function(REMOTE_METADATA_BATCH_PLUS_CACHE_COLD_ID, |b| {
+        b.to_async(&runtime).iter(|| async {
+            let mut provider = CachedDictionaryHintProvider::with_capacity(
+                SimBatchOnlyDictionaryHintProvider::new(Arc::clone(&dictionary_hints), latency),
+                metadata.num_row_groups() * key_columns,
+            );
+            let result = prune_with_provider(
+                black_box(&metadata),
+                black_box(&schema),
+                black_box(&predicate),
+                &mut provider,
+            )
+            .await;
+            black_box(result.row_groups());
+        });
+    });
+
+    group.bench_function(REMOTE_PRUNE_SCAN_BATCH_PLUS_CACHE_COLD_ID, |b| {
+        b.to_async(&runtime).iter(|| async {
+            let mut provider = CachedDictionaryHintProvider::with_capacity(
+                SimBatchOnlyDictionaryHintProvider::new(Arc::clone(&dictionary_hints), latency),
+                metadata.num_row_groups() * key_columns,
+            );
+            let result = prune_with_provider(
+                black_box(&metadata),
+                black_box(&schema),
+                black_box(&predicate),
+                &mut provider,
+            )
+            .await;
             let stats = scan_file_async(
                 temp_file.path(),
                 result.row_groups(),
@@ -343,5 +1060,9 @@ fn bench_dictionary_hints_candidate(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_dictionary_hints_candidate);
+criterion_group!(
+    benches,
+    bench_dictionary_hints_candidate,
+    bench_dictionary_hints_remote_sim
+);
 criterion_main!(benches);

--- a/benches/df_compare/results/dictionary_hints_measured_impact.md
+++ b/benches/df_compare/results/dictionary_hints_measured_impact.md
@@ -1,5 +1,8 @@
 # Dictionary Hints MVP - Measured Impact
 
+> Provider strategy follow-up (`no cache` / `batch only` / `batch + cache`) is tracked in
+> `benches/df_compare/results/dictionary_hints_provider_optimization.md`.
+
 ## Run Context
 
 - Date (UTC): 2026-02-17

--- a/benches/df_compare/results/dictionary_hints_provider_optimization.md
+++ b/benches/df_compare/results/dictionary_hints_provider_optimization.md
@@ -1,0 +1,87 @@
+# Dictionary Hints Provider Optimization (Batch + Cache)
+
+- Date (UTC): `2026-02-18T16:45:31Z`
+- Git commit: `0f8c7a7`
+- Branch: `feat/dictionary-hints-provider-optimization`
+- OS: `Linux 6.17.0-14-generic x86_64 GNU/Linux`
+- Rust: `rustc 1.92.0 (ded5c06cf 2025-12-08)`
+- Cargo: `cargo 1.92.0 (344c4567c 2025-10-21)`
+
+## Commands
+
+```bash
+# Before baseline
+cargo bench --manifest-path benches/df_compare/Cargo.toml --bench dictionary_hints -- --save-baseline dict_hints_provider_before --sample-size 10
+
+# After comparison
+cargo bench --manifest-path benches/df_compare/Cargo.toml --bench dictionary_hints -- --baseline dict_hints_provider_before --sample-size 10
+```
+
+## Strategy Modes
+
+- `no cache`
+  - IDs: `aisle_metadata_only_candidate`, `aisle_prune_plus_scan_candidate`
+- `batch only`
+  - IDs: `aisle_metadata_only_batch_only`, `aisle_prune_plus_scan_batch_only`
+- `batch + cache`
+  - IDs: `aisle_metadata_only_batch_plus_cache`, `aisle_prune_plus_scan_batch_plus_cache`
+- `batch + cache (cold)`
+  - IDs: `aisle_metadata_only_remote_batch_plus_cache_cold`, `aisle_prune_plus_scan_remote_batch_plus_cache_cold`
+
+## Scenario-Level Pruning/Read Indicators (all modes)
+
+Query: `key = 'target_07'`
+
+- Row groups kept: `4 / 64`
+- Pages kept: `8 / 128`
+- Rows read: `8192`
+- Rows matched: `1024`
+- Rows read proxy (`rows_read / total_rows`): `6.25%`
+
+## Before/After Latency (Criterion Mean)
+
+| Mode | Benchmark ID | Before | After | Delta |
+|---|---|---:|---:|---:|
+| no cache | `aisle_metadata_only_candidate` | `93.890 µs` | `93.657 µs` | `-0.25%` |
+| no cache | `aisle_prune_plus_scan_candidate` | `684.668 µs` | `672.847 µs` | `-1.73%` |
+| batch only | `aisle_metadata_only_batch_only` | `99.182 µs` | `99.466 µs` | `+0.29%` |
+| batch only | `aisle_prune_plus_scan_batch_only` | `658.592 µs` | `703.286 µs` | `+6.79%` |
+| batch + cache | `aisle_metadata_only_batch_plus_cache` | `96.267 µs` | `94.972 µs` | `-1.35%` |
+| batch + cache | `aisle_prune_plus_scan_batch_plus_cache` | `772.774 µs` | `726.060 µs` | `-6.05%` |
+
+## Interpretation
+
+- Metadata-only overhead did **not** show a broad, significant improvement across all modes.
+- `no cache`: no statistically significant change (`p > 0.05`).
+- `batch only`: metadata-only unchanged; prune+scan regressed (`p < 0.05`).
+- `batch + cache`: metadata-only slight improvement (small), prune+scan improved directionally but not significant (`p > 0.05`).
+
+## Recommendation
+
+- Use `batch + cache` as the default provider strategy for repeated query workloads over the same file/metadata.
+- For one-shot queries, `no cache` and `batch only` remain comparable in metadata-only latency.
+- Keep conservative pruning semantics unchanged: only `DictionaryHintEvidence::Exact` drives pruning.
+
+## Remote Simulation Benchmark (Strategy Visibility)
+
+To model object-store-like costs, benchmark now includes a remote simulation mode with latency:
+
+- `single lookup`: `base_rtt + per_item_cost`
+- `batch lookup`: `base_rtt + per_item_cost * batch_size`
+- Config used: `base_rtt=200µs`, `per_item=30µs`
+- Workload: `24` row groups, `8` dictionary-hinted key columns, `AND` equality across all key columns.
+
+Measured (same run):
+
+| Mode | Metadata-only latency | Prune+scan latency |
+|---|---:|---:|
+| `no cache` | `[264.35 ms, 265.90 ms, 267.48 ms]` | `[266.81 ms, 268.54 ms, 270.58 ms]` |
+| `batch only` | `[39.554 ms, 39.664 ms, 39.823 ms]` | `[44.627 ms, 45.199 ms, 45.755 ms]` |
+| `batch + cache` (warm) | `[246.64 µs, 247.65 µs, 249.24 µs]` | `[1.5979 ms, 1.6509 ms, 1.7187 ms]` |
+| `batch + cache` (cold) | `[46.316 ms, 46.706 ms, 47.284 ms]` | `[50.364 ms, 51.168 ms, 51.885 ms]` |
+
+Remote-sim takeaway:
+
+- `batch only` shows a clear reduction vs `no cache` when each row-group request includes many hinted columns.
+- Warm `batch + cache` collapses metadata lookup cost to near in-memory overhead.
+- Cold `batch + cache` remains near the batch-only range (expected: first query still has remote-like fetch cost).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -406,8 +406,8 @@ pub use compile::{CompilePruningIr, compile_pruning_ir};
 pub use error::AisleError;
 pub use expr::{CmpOp, Expr};
 pub use prune::{
-    AsyncBloomFilterProvider, DictionaryHintEvidence, DictionaryHintValue, PruneOptions,
-    PruneOptionsBuilder, PruneRequest, PruneResult,
+    AsyncBloomFilterProvider, CachedDictionaryHintProvider, DictionaryHintEvidence,
+    DictionaryHintValue, PruneOptions, PruneOptionsBuilder, PruneRequest, PruneResult,
 };
 pub use pruner::{CompiledPruner, Pruner};
 pub use result::AisleResult;

--- a/src/prune/mod.rs
+++ b/src/prune/mod.rs
@@ -18,6 +18,9 @@ mod strings;
 
 pub(crate) use api::{prune_compiled, prune_compiled_with_bloom_provider};
 pub use options::{PruneOptions, PruneOptionsBuilder};
-pub use provider::{AsyncBloomFilterProvider, DictionaryHintEvidence, DictionaryHintValue};
+pub use provider::{
+    AsyncBloomFilterProvider, CachedDictionaryHintProvider, DictionaryHintEvidence,
+    DictionaryHintValue,
+};
 pub use request::PruneRequest;
 pub use result::PruneResult;

--- a/src/prune/provider.rs
+++ b/src/prune/provider.rs
@@ -48,6 +48,130 @@ pub enum DictionaryHintEvidence {
     Unknown,
 }
 
+/// Provider adapter that caches dictionary hint evidence across calls.
+///
+/// This wrapper is useful when repeated pruning requests touch the same
+/// `(row_group_idx, column_idx)` pairs, for example in metadata-only loops
+/// over the same file.
+///
+/// Cache entries store both `Exact` and `Unknown` evidence. Caching `Unknown`
+/// is conservative and correctness-safe: it may reduce pruning opportunities
+/// if upstream evidence changes, but it cannot introduce false pruning.
+#[derive(Debug, Clone)]
+pub struct CachedDictionaryHintProvider<P> {
+    inner: P,
+    cache: HashMap<(usize, usize), DictionaryHintEvidence>,
+}
+
+impl<P> CachedDictionaryHintProvider<P> {
+    /// Create a new cached provider wrapper.
+    pub fn new(inner: P) -> Self {
+        Self {
+            inner,
+            cache: HashMap::new(),
+        }
+    }
+
+    /// Create a new cached provider wrapper with explicit cache capacity.
+    pub fn with_capacity(inner: P, capacity: usize) -> Self {
+        Self {
+            inner,
+            cache: HashMap::with_capacity(capacity),
+        }
+    }
+
+    /// Access the wrapped provider by reference.
+    pub fn inner(&self) -> &P {
+        &self.inner
+    }
+
+    /// Access the wrapped provider by mutable reference.
+    pub fn inner_mut(&mut self) -> &mut P {
+        &mut self.inner
+    }
+
+    /// Consume this wrapper and return the wrapped provider.
+    pub fn into_inner(self) -> P {
+        self.inner
+    }
+
+    /// Remove all cached dictionary hint evidence.
+    pub fn clear_dictionary_cache(&mut self) {
+        self.cache.clear();
+    }
+
+    /// Number of cached `(row_group_idx, column_idx)` entries.
+    pub fn cached_entries(&self) -> usize {
+        self.cache.len()
+    }
+}
+
+impl<P: AsyncBloomFilterProvider> AsyncBloomFilterProvider for CachedDictionaryHintProvider<P> {
+    fn bloom_filter(
+        &mut self,
+        row_group_idx: usize,
+        column_idx: usize,
+    ) -> impl Future<Output = Option<Sbbf>> + '_ {
+        self.inner.bloom_filter(row_group_idx, column_idx)
+    }
+
+    fn bloom_filters_batch<'a>(
+        &'a mut self,
+        requests: &'a [(usize, usize)],
+    ) -> impl Future<Output = HashMap<(usize, usize), Sbbf>> + 'a {
+        self.inner.bloom_filters_batch(requests)
+    }
+
+    fn dictionary_hints(
+        &mut self,
+        row_group_idx: usize,
+        column_idx: usize,
+    ) -> impl Future<Output = DictionaryHintEvidence> + '_ {
+        async move {
+            let key = (row_group_idx, column_idx);
+            if let Some(evidence) = self.cache.get(&key) {
+                return evidence.clone();
+            }
+
+            let evidence = self.inner.dictionary_hints(row_group_idx, column_idx).await;
+            self.cache.insert(key, evidence.clone());
+            evidence
+        }
+    }
+
+    fn dictionary_hints_batch<'a>(
+        &'a mut self,
+        requests: &'a [(usize, usize)],
+    ) -> impl Future<Output = HashMap<(usize, usize), DictionaryHintEvidence>> + 'a {
+        async move {
+            let mut result = HashMap::with_capacity(requests.len());
+            let mut missing = Vec::new();
+
+            for &request in requests {
+                if let Some(evidence) = self.cache.get(&request) {
+                    result.insert(request, evidence.clone());
+                } else {
+                    missing.push(request);
+                }
+            }
+
+            if !missing.is_empty() {
+                let loaded = self.inner.dictionary_hints_batch(&missing).await;
+                for request in missing {
+                    let evidence = loaded
+                        .get(&request)
+                        .cloned()
+                        .unwrap_or(DictionaryHintEvidence::Unknown);
+                    self.cache.insert(request, evidence.clone());
+                    result.insert(request, evidence);
+                }
+            }
+
+            result
+        }
+    }
+}
+
 /// Async bloom filter provider trait for custom I/O strategies.
 ///
 /// This trait allows users to implement custom bloom filter loading strategies,


### PR DESCRIPTION
 ## What changed

  - Optimized pruning request execution in `src/prune/api.rs`:
    - Resolve bloom/dictionary column indices once per prune call.
    - Reuse resolved indices per row group for batch loading.
    - Keep pruning semantics conservative (`Exact` required for pruning).

  - Added cached dictionary provider support and exports:
    - Added `CachedDictionaryHintProvider` in `src/prune/provider.rs`.
    - Re-exported from `src/prune/mod.rs` and `src/lib.rs`.

  - Added provider strategy benchmark coverage in `benches/df_compare/benches/dictionary_hints.rs`:
    - Modes: `no cache`, `batch only`, `batch + cache`.
    - Added remote-simulation mode with configurable latency model.
    - Added warm vs cold cache benchmark IDs for visibility.

  - Updated benchmark docs/results:
    - `benches/df_compare/README.md`
    - `benches/df_compare/results/dictionary_hints_measured_impact.md`
    - `benches/df_compare/results/dictionary_hints_provider_optimization.md`
    - Enabled `tokio` `time` feature in `benches/df_compare/Cargo.toml`.

  ## Correctness hardening (P1/P2 follow-up)

  - Replaced mutable inner access with explicit retarget API:
    - Removed `inner_mut()`.
    - Added `retarget_inner(&mut self, inner: P) -> P` which clears cache on retarget.
    - Prevents stale cache reuse across provider source/file changes.

  - Changed cache policy to avoid pinning transient unknowns:
    - Cache only `DictionaryHintEvidence::Exact`.
    - Do not cache `Unknown` (including batch omission fallback).

  ## Tests added/updated (`tests/dictionary_hints.rs`)

  - Added helper to build two-file metadata variants for retargeting tests.
  - Added `cached_dictionary_provider_retarget_without_clear_should_not_false_prune`.
    - Verifies retargeting does not reuse stale evidence.
  - Added `cached_dictionary_provider_does_not_pin_transient_unknowns`.
    - Verifies first `Unknown` can recover to `Exact` on later calls.
  - Existing dictionary hint tests remain passing.

  ## Validation

  - `cargo test -p aisle --test dictionary_hints`
  - `cargo test -p aisle`

  Both passed.

  ## API note

  - `CachedDictionaryHintProvider::inner_mut()` was removed.
  - Use `retarget_inner(...)` when changing provider source, or `into_inner()` to consume the wrapper.
