### PR TITLE
chore: bump aisle to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "aisle"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "arrow-arith",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ name = "aisle"
 readme = "README.md"
 repository = "https://github.com/tonbo-io/aisle"
 rust-version = "1.85"
-version = "0.2.0"
+version = "0.2.1"
 
 [dependencies]
 arrow-arith = { version = "57.1.0", optional = true }


### PR DESCRIPTION
## Summary

- bump `aisle` from `0.2.0` to `0.2.1`
- update `Cargo.lock` to match the release version

## Why

Tonbo `0.4.0-a1` depends on the current Aisle APIs that are present on `main` but not in the published `0.2.0` crate.

## Validation

- `env RUSTC_WRAPPER= cargo publish --dry-run --allow-dirty`

Notes:

- The dry-run packages and verifies `aisle v0.2.1`.
- Cargo warns that `lz4_flex v0.12.0` in `Cargo.lock` is yanked.
